### PR TITLE
Fix incompatible-pointer-type build error.

### DIFF
--- a/http/CFHTTPConnection.m
+++ b/http/CFHTTPConnection.m
@@ -287,7 +287,7 @@ static void ReadStreamClientCallback(CFReadStreamRef readStream, CFStreamEventTy
     }
     
     if ([[[url scheme] lowercaseString] isEqualToString:@"https"]) {
-        NSMutableDictionary *sslProperties = [NSDictionary dictionaryWithObjectsAndKeys:
+        NSMutableDictionary *sslProperties = [NSMutableDictionary  dictionaryWithObjectsAndKeys:
                                               (NSString *)kCFStreamSocketSecurityLevelNegotiatedSSL, kCFStreamSSLLevel,
                                               kCFBooleanTrue, kCFStreamSSLAllowsExpiredCertificates,
                                               kCFBooleanTrue, kCFStreamSSLAllowsExpiredRoots,


### PR DESCRIPTION
Make Xcode 5.0.1 happy by calling dictionaryWithObjectsAndKeys on
NSMutableDictionary instead of NSDictionary.

Fixes the error:
	Incompatible pointer types initializing 'NSMutableDictionary *'
	with an expression of type 'NSDictionary *'